### PR TITLE
NorthwindDbContextInitializer - make random less random

### DIFF
--- a/Src/Infrastructure/Persistence/NorthwindDbContextInitializer.cs
+++ b/Src/Infrastructure/Persistence/NorthwindDbContextInitializer.cs
@@ -67,6 +67,9 @@ public class NorthwindDbContextInitializer
     {
         try
         {
+            // don't be random, be consistent! otherwise this may generate names etc that are too big for DB columns
+            Randomizer.Seed = new Random(420);
+            
             await SeedCustomersAsync(cancellationToken);
             await SeedCategoriesAsync(cancellationToken);
             await SeedRegionsAsync(cancellationToken);


### PR DESCRIPTION
By using a consistent data seeder, we avoid issues where Bogus generates names and other fields which are too long for the database.

Experienced this a few times today when running the tests on this project.